### PR TITLE
Added ability to use optional foo.TIMESTAMP.js naming convention

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,19 @@ var gutil = require('gulp-util'),
 const PLUGIN_NAME = 'gulp-cache-break';
 const TIMESTAMP = new Date().getTime();
 
-module.exports = function(assetPath){
+module.exports = function(assetPath, options){
 
   if (!assetPath) {
     throw new PluginError(PLUGIN_NAME, "Missing assetPath!");
   }
+
+  /**
+   * Where the cache-busting timestamp will reside in the file name
+   * append:   foo.js?rel=TIMESTAMP  the default
+   * filename: foo.TIMESTAMP.js
+   * @type string
+   */
+  var position = (options && options.hasOwnProperty('position')) ? options.position : 'append';
 
   /**
    * Append a timestamp to a string
@@ -17,6 +25,10 @@ module.exports = function(assetPath){
    * @returns {String}
    */
   var makeNewUrl = function( filename ) {
+    if (position === 'filename') {
+      return filename.replace(/^(.+)(\.[\w\d]+)$/, '$1.' + TIMESTAMP + '$2');
+    }
+
     return (filename + '?rel=' + TIMESTAMP);
   };
 
@@ -26,6 +38,10 @@ module.exports = function(assetPath){
    * @returns {RegExp}
    */
   var makeTagRegex = function( string ) {
+    if (position === 'filename') {
+      return new RegExp( string.replace(/^(.+)(\.[\w\d]+)$/, '$1(\.\\d+)?$2') );
+    }
+
     return new RegExp( string + '(.+)?(?=")' );
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-cache-break",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Append a timestamp to asset URLs in a web app",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The default is still the original `?rel=TIMESTAMP` configuration, if you don't include any options.

Now, you can include a second parameter of options, and if your options includes a position of "filename", the file will be formatted differently.

This is the same option found in https://github.com/shakyShane/grunt-cache-breaker

So now you can do:

```
cacheBreak(file, {position: 'filename'})
```
